### PR TITLE
bugfix: change port to 80 from 8080

### DIFF
--- a/ubuntu/16/Dockerfile
+++ b/ubuntu/16/Dockerfile
@@ -27,6 +27,6 @@ EXPOSE 29418 8080
 VOLUME ["/var/gerrit/git", "/var/gerrit/index", "/var/gerrit/cache", "/var/gerrit/db", "/var/gerrit/etc"]
 
 # Start Gerrit
-CMD git config -f /var/gerrit/etc/gerrit.config gerrit.canonicalWebUrl "${CANONICAL_WEB_URL:-http://$HOSTNAME:8080/}" && \
+CMD git config -f /var/gerrit/etc/gerrit.config gerrit.canonicalWebUrl "${CANONICAL_WEB_URL:-http://$HOSTNAME:80/}" && \
     git config -f /var/gerrit/etc/gerrit.config noteDb.changes.autoMigrate true && \
         /var/gerrit/bin/gerrit.sh run


### PR DESCRIPTION
Change CANONICAL_WEB_URL to http://$HOSTNAME:80/. Because 80 is the default web port. And according to the file docker-compose.yaml in the README, outside port 80 is mapped to 8080 inside the gerrit container.
Or, directly remove 8080.

# Important Notice

Patch submission and review is done through [Gerrit Code Review](https://gerrit-review.googlesource.com).
Unfortunately we cannot pull your code as a Pull Request.

__NO REVIEWS OR DISCUSSIONS will happen on GitHub__, all the code collaboration
will take place on Gerrit.
