### PR TITLE
ubuntu: use only JRE headless

### DIFF
--- a/ubuntu/18/Dockerfile
+++ b/ubuntu/18/Dockerfile
@@ -15,7 +15,7 @@ ADD entrypoint.sh /
 
 # Install OpenJDK and Gerrit in two subsequent transactions
 # (pre-trans Gerrit script needs to have access to the Java command)
-RUN apt-get -y install openjdk-8-jdk
+RUN apt-get -y install openjdk-8-jre-headless
 RUN apt-get -y install gerrit=3.1.0-1 && \
     /entrypoint.sh init && \
     rm -f /var/gerrit/etc/{ssh,secure}* && rm -Rf /var/gerrit/{static,index,logs,data,index,cache,git,db,tmp}/* && chown -R gerrit:gerrit /var/gerrit


### PR DESCRIPTION
There's no need to have the full JDK, just the JRE is enough, and we don't need the
UI etc. either, so the headless variant is enough.

# Important Notice

Patch submission and review is done through [Gerrit Code Review](https://gerrit-review.googlesource.com).
Unfortunately we cannot pull your code as a Pull Request.

__NO REVIEWS OR DISCUSSIONS will happen on GitHub__, all the code collaboration
will take place on Gerrit.
